### PR TITLE
Trimmed AMD CPU Names

### DIFF
--- a/src/components/DualMonitor/index.tsx
+++ b/src/components/DualMonitor/index.tsx
@@ -21,7 +21,7 @@ export const DualMonitor = () => {
     <div className="info-container">
       <div className="info-title">
         <CpuIcon color={krakenStore.cpuIcon.color} opacity={krakenStore.cpuIcon.alpha} />
-        <span>{cpu?.name?.replace(/core/gi, '') ?? 'i9 11900K'}</span>
+        <span>{cpu?.name?.replace(/(core|ryzen \d)/gi, '').trim() ?? 'i9 11900K'}</span>
       </div>
       <div className="info-data">
         <div className="info-icon temperature">


### PR DESCRIPTION
Adds Support for Ryzen CPUs. It trims `Ryzen 9 7950X3D` to simply `7950X3D`